### PR TITLE
Improve benchmarks

### DIFF
--- a/crates/mitex-parser/benches/simple.rs
+++ b/crates/mitex-parser/benches/simple.rs
@@ -1,5 +1,8 @@
-use divan::Bencher;
+use divan::{AllocProfiler, Bencher};
 use mitex_parser::{parse, CommandSpec};
+
+#[global_allocator]
+static ALLOC: AllocProfiler = AllocProfiler::system();
 
 fn main() {
     // Run registered benchmarks.

--- a/crates/mitex-parser/benches/simple.rs
+++ b/crates/mitex-parser/benches/simple.rs
@@ -1,3 +1,4 @@
+use divan::Bencher;
 use mitex_parser::{parse, CommandSpec};
 
 fn main() {
@@ -32,40 +33,44 @@ static ALPHA_X_20000: once_cell::sync::Lazy<String> =
 static ALPHA_X_40000: once_cell::sync::Lazy<String> =
     once_cell::sync::Lazy::new(|| "\\alpha x".repeat(40000));
 
-#[divan::bench]
-fn alpha_x_20000() {
-    parse(&ALPHA_X_20000, DEFAULT_SPEC.clone());
+fn bench(bencher: Bencher, input: &str, spec: CommandSpec) {
+    bencher.bench(|| parse(input, spec.clone()));
 }
 
 #[divan::bench]
-fn alpha_x_40000() {
-    parse(&ALPHA_X_40000, DEFAULT_SPEC.clone());
+fn alpha_x_20000(bencher: Bencher) {
+    bench(bencher, &ALPHA_X_20000, DEFAULT_SPEC.clone());
 }
 
 #[divan::bench]
-fn alpha_x_20000_heavy() {
-    parse(&ALPHA_X_20000, HEAVY_SPEC.clone());
+fn alpha_x_40000(bencher: Bencher) {
+    bench(bencher, &ALPHA_X_40000, DEFAULT_SPEC.clone());
 }
 
 #[divan::bench]
-fn alpha_x_40000_heavy() {
-    parse(&ALPHA_X_40000, HEAVY_SPEC.clone());
+fn alpha_x_20000_heavy(bencher: Bencher) {
+    bench(bencher, &ALPHA_X_20000, HEAVY_SPEC.clone());
+}
+
+#[divan::bench]
+fn alpha_x_40000_heavy(bencher: Bencher) {
+    bench(bencher, &ALPHA_X_40000, HEAVY_SPEC.clone());
 }
 
 static SLICE_WORD: once_cell::sync::Lazy<String> =
     once_cell::sync::Lazy::new(|| "\\frac ab ".repeat(20000));
 
 #[divan::bench]
-fn slice_word() {
-    parse(&SLICE_WORD, DEFAULT_SPEC.clone());
+fn slice_word(bencher: Bencher) {
+    bench(bencher, &SLICE_WORD, DEFAULT_SPEC.clone());
 }
 
 static SQRT_PATTERN: once_cell::sync::Lazy<String> =
     once_cell::sync::Lazy::new(|| "\\sqrt[1]{2} \\sqrt{2} \\sqrt{2} \\sqrt{2}".repeat(2500));
 
 #[divan::bench]
-fn sqrt_pattern() {
-    parse(&SQRT_PATTERN, DEFAULT_SPEC.clone());
+fn sqrt_pattern(bencher: Bencher) {
+    bench(bencher, &SQRT_PATTERN, DEFAULT_SPEC.clone());
 }
 
 /*


### PR DESCRIPTION
- Add [allocation profiling](https://nikolaivazquez.com/blog/divan/#measure-allocations). I have [carefully optimized it](https://github.com/nvzqz/divan/blob/main/CHANGELOG.md#018---2023-12-19) so it should not have a noticeable footprint.
- Remove setup cost from benchmarks. Previously benchmarks would include the cost of initializing a `once_cell::sync::Lazy` instance. This reduces benchmarked times by 100-400µs.

Example output:

```
simple                  fastest       │ slowest       │ median        │ mean          │ samples │ iters
├─ alpha_x_20000        1.975 ms      │ 2.168 ms      │ 1.99 ms       │ 1.995 ms      │ 100     │ 100
│                       alloc:        │               │               │               │         │
│                         12          │ 12            │ 12            │ 12            │         │
│                         960.8 KB    │ 960.8 KB      │ 960.8 KB      │ 960.8 KB      │         │
│                       dealloc:      │               │               │               │         │
│                         5           │ 5             │ 5             │ 5             │         │
│                         1.579 MB    │ 1.579 MB      │ 1.579 MB      │ 1.579 MB      │         │
│                       grow:         │               │               │               │         │
│                         18          │ 18            │ 18            │ 18            │         │
│                         1.578 MB    │ 1.578 MB      │ 1.578 MB      │ 1.578 MB      │         │
├─ alpha_x_20000_heavy  2.02 ms       │ 2.338 ms      │ 2.038 ms      │ 2.047 ms      │ 100     │ 100
│                       alloc:        │               │               │               │         │
│                         12          │ 12            │ 12            │ 12            │         │
│                         960.8 KB    │ 960.8 KB      │ 960.8 KB      │ 960.8 KB      │         │
│                       dealloc:      │               │               │               │         │
│                         5           │ 5             │ 5             │ 5             │         │
│                         1.579 MB    │ 1.579 MB      │ 1.579 MB      │ 1.579 MB      │         │
│                       grow:         │               │               │               │         │
│                         18          │ 18            │ 18            │ 18            │         │
│                         1.578 MB    │ 1.578 MB      │ 1.578 MB      │ 1.578 MB      │         │
├─ alpha_x_40000        4.013 ms      │ 4.396 ms      │ 4.044 ms      │ 4.061 ms      │ 100     │ 100
│                       alloc:        │               │               │               │         │
│                         12          │ 12            │ 12            │ 12            │         │
│                         1.92 MB     │ 1.92 MB       │ 1.92 MB       │ 1.92 MB       │         │
│                       dealloc:      │               │               │               │         │
│                         5           │ 5             │ 5             │ 5             │         │
│                         3.152 MB    │ 3.152 MB      │ 3.152 MB      │ 3.152 MB      │         │
│                       grow:         │               │               │               │         │
│                         19          │ 19            │ 19            │ 19            │         │
│                         3.151 MB    │ 3.151 MB      │ 3.151 MB      │ 3.151 MB      │         │
├─ alpha_x_40000_heavy  4.021 ms      │ 4.307 ms      │ 4.116 ms      │ 4.124 ms      │ 100     │ 100
│                       alloc:        │               │               │               │         │
│                         12          │ 12            │ 12            │ 12            │         │
│                         1.92 MB     │ 1.92 MB       │ 1.92 MB       │ 1.92 MB       │         │
│                       dealloc:      │               │               │               │         │
│                         5           │ 5             │ 5             │ 5             │         │
│                         3.152 MB    │ 3.152 MB      │ 3.152 MB      │ 3.152 MB      │         │
│                       grow:         │               │               │               │         │
│                         19          │ 19            │ 19            │ 19            │         │
│                         3.151 MB    │ 3.151 MB      │ 3.151 MB      │ 3.151 MB      │         │
├─ slice_word           2.275 ms      │ 2.707 ms      │ 2.292 ms      │ 2.299 ms      │ 100     │ 100
│                       alloc:        │               │               │               │         │
│                         12          │ 12            │ 12            │ 12            │         │
│                         960.9 KB    │ 960.9 KB      │ 960.9 KB      │ 960.9 KB      │         │
│                       dealloc:      │               │               │               │         │
│                         5           │ 5             │ 5             │ 5             │         │
│                         1.579 MB    │ 1.579 MB      │ 1.579 MB      │ 1.579 MB      │         │
│                       grow:         │               │               │               │         │
│                         18          │ 18            │ 18            │ 18            │         │
│                         1.578 MB    │ 1.578 MB      │ 1.578 MB      │ 1.578 MB      │         │
╰─ sqrt_pattern         1.598 ms      │ 1.752 ms      │ 1.609 ms      │ 1.615 ms      │ 100     │ 100
                        alloc:        │               │               │               │         │
                          7523        │ 7523          │ 7523          │ 7523          │         │
                          1.021 MB    │ 1.021 MB      │ 1.021 MB      │ 1.021 MB      │         │
                        dealloc:      │               │               │               │         │
                          8           │ 8             │ 8             │ 8             │         │
                          793 KB      │ 793 KB        │ 793 KB        │ 793 KB        │         │
                        grow:         │               │               │               │         │
                          17          │ 17            │ 17            │ 17            │         │
                          792 KB      │ 792 KB        │ 792 KB        │ 792 KB        │         │
```