### PR TITLE
feat: add compile_spec api to WASM library

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,6 +3,17 @@
 version = 3
 
 [[package]]
+name = "ahash"
+version = "0.7.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a824f2aa7e75a0c98c5a504fceb80649e9c35265d44525b5f94de4771a395cd"
+dependencies = [
+ "getrandom",
+ "once_cell",
+ "version_check",
+]
+
+[[package]]
 name = "anstyle"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -25,6 +36,46 @@ name = "bitflags"
 version = "2.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "327762f6e5a765692301e5bb513e0d9fef63be86bbc14528052b1cd3e6f03e07"
+
+[[package]]
+name = "bitvec"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1bc2832c24239b0141d5674bb9174f9d68a8b5b3f2753311927c172ca46f7e9c"
+dependencies = [
+ "funty",
+ "radium",
+ "tap",
+ "wyz",
+]
+
+[[package]]
+name = "bytecheck"
+version = "0.6.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b6372023ac861f6e6dc89c8344a8f398fb42aaba2b5dbc649ca0c0e9dbcb627"
+dependencies = [
+ "bytecheck_derive",
+ "ptr_meta",
+ "simdutf8",
+]
+
+[[package]]
+name = "bytecheck_derive"
+version = "0.6.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a7ec4c6f261935ad534c0c22dbef2201b45918860eb1c574b972bd213a76af61"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
+]
+
+[[package]]
+name = "bytes"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a2bd12c1caf447e69cd4528f47f94d203fd2582878ecb9e9465484c4148a8223"
 
 [[package]]
 name = "cfg-if"
@@ -104,7 +155,7 @@ checksum = "d4669c6c0b93fa1848f1aaebd95d2697e3216fd781ac9eb71527e578d9df0f8e"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.41",
 ]
 
 [[package]]
@@ -128,6 +179,32 @@ name = "fnv"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
+
+[[package]]
+name = "funty"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e6d5a32815ae3f33302d95fdcb2ce17862f8c65363dcfd29360480ba1001fc9c"
+
+[[package]]
+name = "getrandom"
+version = "0.2.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fe9006bed769170c11f845cf00c7c1e9092aeb3f268e007c3e760ac68008070f"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "wasi",
+]
+
+[[package]]
+name = "hashbrown"
+version = "0.12.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
+dependencies = [
+ "ahash",
+]
 
 [[package]]
 name = "hashbrown"
@@ -192,7 +269,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "regex-syntax",
- "syn",
+ "syn 2.0.41",
 ]
 
 [[package]]
@@ -262,6 +339,11 @@ dependencies = [
 [[package]]
 name = "mitex-spec"
 version = "0.1.0"
+dependencies = [
+ "divan",
+ "once_cell",
+ "rkyv",
+]
 
 [[package]]
 name = "mitex-typst"
@@ -287,6 +369,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "ptr_meta"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0738ccf7ea06b608c10564b31debd4f5bc5e197fc8bfe088f68ae5ce81e7a4f1"
+dependencies = [
+ "ptr_meta_derive",
+]
+
+[[package]]
+name = "ptr_meta_derive"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "16b845dbfca988fa33db069c0e230574d15a3088f147a87b64c7589eb662c9ac"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
+]
+
+[[package]]
 name = "quote"
 version = "1.0.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -294,6 +396,12 @@ checksum = "5267fca4496028628a95160fc423a33e8b2e6af8a5302579e322e4b520293cae"
 dependencies = [
  "proc-macro2",
 ]
+
+[[package]]
+name = "radium"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc33ff2d4973d518d823d61aa239014831e521c75da58e3df4840d3f47749d09"
 
 [[package]]
 name = "regex-lite"
@@ -308,13 +416,51 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f162c6dd7b008981e4d40210aca20b4bd0f9b60ca9271061b07f78537722f2e1"
 
 [[package]]
+name = "rend"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a2571463863a6bd50c32f94402933f03457a3fbaf697a707c5be741e459f08fd"
+dependencies = [
+ "bytecheck",
+]
+
+[[package]]
+name = "rkyv"
+version = "0.7.43"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "527a97cdfef66f65998b5f3b637c26f5a5ec09cc52a3f9932313ac645f4190f5"
+dependencies = [
+ "bitvec",
+ "bytecheck",
+ "bytes",
+ "hashbrown 0.12.3",
+ "ptr_meta",
+ "rend",
+ "rkyv_derive",
+ "seahash",
+ "tinyvec",
+ "uuid",
+]
+
+[[package]]
+name = "rkyv_derive"
+version = "0.7.43"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b5c462a1328c8e67e4d6dbad1eb0355dd43e8ab432c6e227a43657f16ade5033"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
+]
+
+[[package]]
 name = "rowan"
 version = "0.15.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32a58fa8a7ccff2aec4f39cc45bf5f985cec7125ab271cf681c279fd00192b49"
 dependencies = [
  "countme",
- "hashbrown",
+ "hashbrown 0.14.3",
  "memoffset",
  "rustc-hash",
  "text-size",
@@ -340,10 +486,33 @@ dependencies = [
 ]
 
 [[package]]
+name = "seahash"
+version = "4.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1c107b6f4780854c8b126e228ea8869f4d7b71260f962fefb57b996b8959ba6b"
+
+[[package]]
+name = "simdutf8"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f27f6278552951f1f2b8cf9da965d10969b2efdea95a6ec47987ab46edfe263a"
+
+[[package]]
 name = "similar"
 version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2aeaf503862c419d66959f5d7ca015337d864e9c49485d771b732e2a20453597"
+
+[[package]]
+name = "syn"
+version = "1.0.109"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72b64191b275b66ffe2469e8af2c1cfe3bafa67b529ead792a6d0160888b4237"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-ident",
+]
 
 [[package]]
 name = "syn"
@@ -355,6 +524,12 @@ dependencies = [
  "quote",
  "unicode-ident",
 ]
+
+[[package]]
+name = "tap"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "55937e1799185b12863d447f42597ed69d9928686b8d88a1df17376a097d8369"
 
 [[package]]
 name = "terminal_size"
@@ -373,10 +548,31 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f18aa187839b2bdb1ad2fa35ead8c4c2976b64e4363c386d45ac0f7ee85c9233"
 
 [[package]]
+name = "tinyvec"
+version = "1.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "87cc5ceb3875bb20c2890005a4e226a4651264a5c75edb2421b52861a0a0cb50"
+dependencies = [
+ "tinyvec_macros",
+]
+
+[[package]]
+name = "tinyvec_macros"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
+
+[[package]]
 name = "unicode-ident"
 version = "1.0.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3354b9ac3fae1ff6755cb6db53683adb661634f67557942dea4facebec0fee4b"
+
+[[package]]
+name = "uuid"
+version = "1.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5e395fcf16a7a3d8127ec99782007af141946b4795001f876d54fb0d55978560"
 
 [[package]]
 name = "venial"
@@ -387,6 +583,18 @@ dependencies = [
  "proc-macro2",
  "quote",
 ]
+
+[[package]]
+name = "version_check"
+version = "0.9.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "49874b5167b65d7193b8aba1567f5c7d93d001cafc34600cee003eda787e483f"
+
+[[package]]
+name = "wasi"
+version = "0.11.0+wasi-snapshot-preview1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
 
 [[package]]
 name = "wasm-minimal-protocol"
@@ -595,6 +803,15 @@ name = "windows_x86_64_msvc"
 version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dff9641d1cd4be8d1a070daf9e3773c5f67e78b4d9d42263020c057706765c04"
+
+[[package]]
+name = "wyz"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "05f360fc0b24296329c78fda852a1e9ae82de9cf7b27dae4b7f62f118f77b9ed"
+dependencies = [
+ "tap",
+]
 
 [[package]]
 name = "yaml-rust"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -135,9 +135,9 @@ checksum = "7704b5fdd17b18ae31c4c1da5a2e0305a2bf17b5249300a9ee9ed7b72114c636"
 
 [[package]]
 name = "divan"
-version = "0.1.7"
+version = "0.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "77f3c37609833a14a598385904bd43c79724964bc4b0a3339968da85bec4e1e4"
+checksum = "dbf174e1957cfadab3bcb040afb210ea8b7c2ffc094eb88b750be61fc601835e"
 dependencies = [
  "cfg-if",
  "clap",
@@ -149,9 +149,9 @@ dependencies = [
 
 [[package]]
 name = "divan-macros"
-version = "0.1.7"
+version = "0.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d4669c6c0b93fa1848f1aaebd95d2697e3216fd781ac9eb71527e578d9df0f8e"
+checksum = "510ef69263e119c8ec0213761e397d26a3f6d35e13a454549508446d3578ddc0"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -224,6 +224,12 @@ dependencies = [
  "similar",
  "yaml-rust",
 ]
+
+[[package]]
+name = "itoa"
+version = "1.0.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b1a46d1a171d865aa5f83f92695765caa047a9b4cbae2cbf37dbd613a793fd4c"
 
 [[package]]
 name = "lazy_static"
@@ -343,6 +349,8 @@ dependencies = [
  "divan",
  "once_cell",
  "rkyv",
+ "serde",
+ "serde_json",
 ]
 
 [[package]]
@@ -350,6 +358,9 @@ name = "mitex-typst"
 version = "0.1.0"
 dependencies = [
  "mitex",
+ "mitex-spec",
+ "serde",
+ "serde_json",
  "wasm-minimal-protocol",
 ]
 
@@ -486,10 +497,47 @@ dependencies = [
 ]
 
 [[package]]
+name = "ryu"
+version = "1.0.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f98d2aa92eebf49b69786be48e4477826b256916e84a57ff2a4f21923b48eb4c"
+
+[[package]]
 name = "seahash"
 version = "4.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1c107b6f4780854c8b126e228ea8869f4d7b71260f962fefb57b996b8959ba6b"
+
+[[package]]
+name = "serde"
+version = "1.0.193"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "25dd9975e68d0cb5aa1120c288333fc98731bd1dd12f561e468ea4728c042b89"
+dependencies = [
+ "serde_derive",
+]
+
+[[package]]
+name = "serde_derive"
+version = "1.0.193"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "43576ca501357b9b071ac53cdc7da8ef0cbd9493d8df094cd821777ea6e894d3"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.41",
+]
+
+[[package]]
+name = "serde_json"
+version = "1.0.108"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3d1c7e3eac408d115102c4c24ad393e0821bb3a5df4d506a80f85f7a742a526b"
+dependencies = [
+ "itoa",
+ "ryu",
+ "serde",
+]
 
 [[package]]
 name = "simdutf8"

--- a/crates/mitex-parser/src/lib.rs
+++ b/crates/mitex-parser/src/lib.rs
@@ -1,112 +1,12 @@
 mod arg_match;
 pub mod parser;
-pub use mitex_spec as spec;
 pub mod syntax;
 
 pub use parser::parse;
 pub use spec::*;
 
-pub mod command_preludes {
-    use crate::{ArgShape, CommandSpecItem};
-
-    pub fn define_command(num: u8) -> CommandSpecItem {
-        CommandSpecItem::Cmd(crate::CmdShape {
-            args: crate::ArgShape::Right(crate::ArgPattern::FixedLenTerm(num)),
-            alias: None,
-        })
-    }
-
-    pub fn define_glob_command(reg: &str, alias: &str) -> CommandSpecItem {
-        CommandSpecItem::Cmd(crate::CmdShape {
-            args: crate::ArgShape::Right(crate::ArgPattern::Glob(reg.into())),
-            alias: Some(alias.to_owned()),
-        })
-    }
-
-    pub fn define_symbol(alias: &str) -> CommandSpecItem {
-        CommandSpecItem::Cmd(crate::CmdShape {
-            args: crate::ArgShape::Right(crate::ArgPattern::None),
-            alias: Some(alias.to_owned()),
-        })
-    }
-
-    pub fn define_command_with_alias(num: u8, alias: &str) -> CommandSpecItem {
-        CommandSpecItem::Cmd(crate::CmdShape {
-            args: crate::ArgShape::Right(crate::ArgPattern::FixedLenTerm(num)),
-            alias: Some(alias.to_owned()),
-        })
-    }
-
-    pub fn define_greedy_command(alias: &str) -> CommandSpecItem {
-        CommandSpecItem::Cmd(crate::CmdShape {
-            args: crate::ArgShape::Right(crate::ArgPattern::Greedy),
-            alias: Some(alias.to_owned()),
-        })
-    }
-
-    pub fn define_matrix_env(num: Option<u8>, alias: &str) -> CommandSpecItem {
-        CommandSpecItem::Env(crate::EnvShape {
-            args: num
-                .map(crate::ArgPattern::FixedLenTerm)
-                .unwrap_or(crate::ArgPattern::None),
-            ctx_feature: crate::ContextFeature::IsMatrix,
-            alias: Some(alias.to_owned()),
-        })
-    }
-
-    pub fn define_normal_env(num: Option<u8>, alias: &str) -> CommandSpecItem {
-        CommandSpecItem::Env(crate::EnvShape {
-            args: num
-                .map(crate::ArgPattern::FixedLenTerm)
-                .unwrap_or(crate::ArgPattern::None),
-            ctx_feature: crate::ContextFeature::None,
-            alias: Some(alias.to_owned()),
-        })
-    }
-    pub const fn define_const_command(args: ArgShape) -> CommandSpecItem {
-        CommandSpecItem::Cmd(crate::CmdShape { args, alias: None })
-    }
-
-    pub const TEX_CMD0: CommandSpecItem =
-        define_const_command(crate::ArgShape::Right(crate::ArgPattern::FixedLenTerm(0)));
-    pub const TEX_CMD1: CommandSpecItem =
-        define_const_command(crate::ArgShape::Right(crate::ArgPattern::FixedLenTerm(1)));
-    pub const TEX_CMD2: CommandSpecItem =
-        define_const_command(crate::ArgShape::Right(crate::ArgPattern::FixedLenTerm(2)));
-    pub const TEX_SYMBOL: CommandSpecItem =
-        define_const_command(crate::ArgShape::Right(crate::ArgPattern::None));
-    pub const TEX_LEFT1_OPEARTOR: CommandSpecItem = define_const_command(crate::ArgShape::Left1);
-    pub const TEX_GREEDY_OPERATOR: CommandSpecItem =
-        define_const_command(crate::ArgShape::Right(crate::ArgPattern::Greedy));
-    pub const TEX_INFIX_OPERATOR: CommandSpecItem =
-        define_const_command(crate::ArgShape::InfixGreedy);
-    pub const TEX_MATRIX_ENV: CommandSpecItem = CommandSpecItem::Env(crate::EnvShape {
-        args: crate::ArgPattern::None,
-        ctx_feature: crate::ContextFeature::IsMatrix,
-        alias: None,
-    });
-    pub const TEX_NORMAL_ENV: CommandSpecItem = CommandSpecItem::Env(crate::EnvShape {
-        args: crate::ArgPattern::None,
-        ctx_feature: crate::ContextFeature::None,
-        alias: None,
-    });
-
-    #[derive(Default)]
-    pub struct SpecBuilder {
-        commands: std::collections::HashMap<String, CommandSpecItem>,
-    }
-
-    impl SpecBuilder {
-        pub fn add_command(&mut self, name: &str, item: CommandSpecItem) -> &mut Self {
-            self.commands.insert(name.to_owned(), item);
-            self
-        }
-
-        pub fn build(self) -> crate::CommandSpec {
-            crate::CommandSpec::new(self.commands)
-        }
-    }
-}
+pub use mitex_spec as spec;
+pub use spec::preludes::command as command_preludes;
 
 #[cfg(test)]
 mod tests {

--- a/crates/mitex-spec/Cargo.toml
+++ b/crates/mitex-spec/Cargo.toml
@@ -14,6 +14,8 @@ harness = false
 
 [dependencies]
 rkyv = { version = "0.7.42", optional = true }
+serde = { version = "1.0.188", features = ["derive"] }
+serde_json = "1.0.106"
 
 [features]
 

--- a/crates/mitex-spec/Cargo.toml
+++ b/crates/mitex-spec/Cargo.toml
@@ -7,3 +7,20 @@ license.workspace = true
 edition.workspace = true
 homepage.workspace = true
 repository.workspace = true
+
+[[bench]]
+name = "constructions"
+harness = false
+
+[dependencies]
+rkyv = { version = "0.7.42", optional = true }
+
+[features]
+
+rkyv = ["dep:rkyv", "rkyv/alloc", "rkyv/archive_le"]
+rkyv-validation = ["dep:rkyv", "rkyv/validation"]
+default = ["rkyv", "rkyv-validation"]
+
+[dev-dependencies]
+once_cell = "1"
+divan = "0.1.7"

--- a/crates/mitex-spec/benches/constructions.rs
+++ b/crates/mitex-spec/benches/constructions.rs
@@ -1,0 +1,158 @@
+use divan::{AllocProfiler, Bencher};
+use mitex_spec::CommandSpec;
+
+#[global_allocator]
+static ALLOC: AllocProfiler = AllocProfiler::system();
+
+fn main() {
+    // Run registered benchmarks.
+    divan::main();
+}
+
+fn prelude_n(n: i32) -> CommandSpec {
+    use mitex_spec::preludes::command::*;
+    let mut builder = SpecBuilder::default();
+    for i in 0..n {
+        builder.add_command(&format!("alpha{}", i), TEX_SYMBOL);
+    }
+    builder.build()
+}
+
+#[divan::bench]
+fn prelude_1() {
+    prelude_n(1);
+}
+
+#[divan::bench]
+fn prelude_1000() {
+    prelude_n(1000);
+}
+
+#[divan::bench]
+fn prelude_100000() {
+    prelude_n(100000);
+}
+
+#[cfg(feature = "rkyv")]
+#[cfg(feature = "rkyv-validation")]
+fn bench_deserialize(bencher: Bencher, spec: CommandSpec) {
+    let bytes = spec.to_bytes();
+    bencher.bench(|| {
+        let _ = CommandSpec::from_bytes(&bytes);
+    });
+}
+
+#[divan::bench]
+#[cfg(feature = "rkyv")]
+#[cfg(feature = "rkyv-validation")]
+fn deserialize_1(bencher: Bencher) {
+    bench_deserialize(bencher, prelude_n(1));
+}
+
+#[divan::bench]
+#[cfg(feature = "rkyv")]
+#[cfg(feature = "rkyv-validation")]
+fn deserialize_1000(bencher: Bencher) {
+    bench_deserialize(bencher, prelude_n(1000));
+}
+
+#[divan::bench]
+#[cfg(feature = "rkyv")]
+#[cfg(feature = "rkyv-validation")]
+fn deserialize_100000(bencher: Bencher) {
+    bench_deserialize(bencher, prelude_n(100000));
+}
+
+#[cfg(feature = "rkyv")]
+fn bench_deserialize_trusted(bencher: Bencher, spec: CommandSpec) {
+    let bytes = spec.to_bytes();
+    bencher.bench(|| {
+        let _ = unsafe { CommandSpec::from_bytes_unchecked(&bytes) };
+    });
+}
+
+#[divan::bench]
+#[cfg(feature = "rkyv")]
+fn deserialize_trusted_1(bencher: Bencher) {
+    bench_deserialize_trusted(bencher, prelude_n(1));
+}
+
+#[divan::bench]
+#[cfg(feature = "rkyv")]
+fn deserialize_trusted_1000(bencher: Bencher) {
+    bench_deserialize_trusted(bencher, prelude_n(1000));
+}
+
+#[divan::bench]
+#[cfg(feature = "rkyv")]
+fn deserialize_trusted_100000(bencher: Bencher) {
+    bench_deserialize_trusted(bencher, prelude_n(100000));
+}
+
+/*
+last^1
+constructions                  fastest       │ slowest       │ median        │ mean          │ samples │ iters
+├─ deserialize_1               199.8 ns      │ 11.09 µs      │ 299.8 ns      │ 397.8 ns      │ 100     │ 100
+│                              alloc:        │               │               │               │         │
+│                                3           │ 3             │ 3             │ 3             │         │
+│                                410 B       │ 410 B         │ 410 B         │ 410 B         │         │
+│                              dealloc:      │               │               │               │         │
+│                                3           │ 3             │ 3             │ 3             │         │
+│                                410 B       │ 410 B         │ 410 B         │ 410 B         │         │
+├─ deserialize_1000            107.7 µs      │ 596.8 µs      │ 117 µs        │ 124.2 µs      │ 100     │ 100
+│                              alloc:        │               │               │               │         │
+│                                1002        │ 1002          │ 1002          │ 1002          │         │
+│                                173.8 KB    │ 173.8 KB      │ 173.8 KB      │ 173.8 KB      │         │
+│                              dealloc:      │               │               │               │         │
+│                                1002        │ 1002          │ 1002          │ 1002          │         │
+│                                173.8 KB    │ 173.8 KB      │ 173.8 KB      │ 173.8 KB      │         │
+├─ deserialize_100000          17.45 ms      │ 29.96 ms      │ 20.27 ms      │ 20.76 ms      │ 100     │ 100
+│                              alloc:        │               │               │               │         │
+│                                100002      │ 100002        │ 100002        │ 100002        │         │
+│                                11.6 MB     │ 11.6 MB       │ 11.6 MB       │ 11.6 MB       │         │
+│                              dealloc:      │               │               │               │         │
+│                                100002      │ 100002        │ 100002        │ 100002        │         │
+│                                11.6 MB     │ 11.6 MB       │ 11.6 MB       │ 11.6 MB       │         │
+├─ deserialize_trusted_1       143.6 ns      │ 295.2 ns      │ 149.8 ns      │ 169 ns        │ 100     │ 6400
+│                              alloc:        │               │               │               │         │
+│                                3           │ 3             │ 3             │ 3             │         │
+│                                410 B       │ 410 B         │ 410 B         │ 410 B         │         │
+│                              dealloc:      │               │               │               │         │
+│                                3           │ 3             │ 3             │ 3             │         │
+│                                410 B       │ 410 B         │ 410 B         │ 410 B         │         │
+├─ deserialize_trusted_1000    80.59 µs      │ 568.8 µs      │ 154.1 µs      │ 163.1 µs      │ 100     │ 100
+│                              alloc:        │               │               │               │         │
+│                                1002        │ 1002          │ 1002          │ 1002          │         │
+│                                173.8 KB    │ 173.8 KB      │ 173.8 KB      │ 173.8 KB      │         │
+│                              dealloc:      │               │               │               │         │
+│                                1002        │ 1002          │ 1002          │ 1002          │         │
+│                                173.8 KB    │ 173.8 KB      │ 173.8 KB      │ 173.8 KB      │         │
+├─ deserialize_trusted_100000  10.86 ms      │ 20.24 ms      │ 14.07 ms      │ 14.24 ms      │ 100     │ 100
+│                              alloc:        │               │               │               │         │
+│                                100002      │ 100002        │ 100002        │ 100002        │         │
+│                                11.6 MB     │ 11.6 MB       │ 11.6 MB       │ 11.6 MB       │         │
+│                              dealloc:      │               │               │               │         │
+│                                100002      │ 100002        │ 100002        │ 100002        │         │
+│                                11.6 MB     │ 11.6 MB       │ 11.6 MB       │ 11.6 MB       │         │
+├─ prelude_1                   193.6 ns      │ 226.4 ns      │ 198.3 ns      │ 203.5 ns      │ 100     │ 6400
+│                              alloc:        │               │               │               │         │
+│                                4           │ 4             │ 4             │ 4             │         │
+│                                420 B       │ 420 B         │ 420 B         │ 420 B         │         │
+│                              dealloc:      │               │               │               │         │
+│                                4           │ 4             │ 4             │ 4             │         │
+│                                420 B       │ 420 B         │ 420 B         │ 420 B         │         │
+├─ prelude_1000                182.7 µs      │ 2.092 ms      │ 216.3 µs      │ 250.5 µs      │ 100     │ 100
+│                              alloc:        │               │               │               │         │
+│                                2011        │ 2011          │ 2011          │ 2011          │         │
+│                                349.5 KB    │ 349.5 KB      │ 349.5 KB      │ 349.5 KB      │         │
+│                              dealloc:      │               │               │               │         │
+│                                2011        │ 2011          │ 2011          │ 2011          │         │
+│                                349.5 KB    │ 349.5 KB      │ 349.5 KB      │ 349.5 KB      │         │
+╰─ prelude_100000              20.84 ms      │ 33.22 ms      │ 24.95 ms      │ 25.48 ms      │ 100     │ 100
+                               alloc:        │               │               │               │         │
+                                 200017      │ 200017        │ 200017        │ 200017        │         │
+                                 23.22 MB    │ 23.22 MB      │ 23.22 MB      │ 23.22 MB      │         │
+                               dealloc:      │               │               │               │         │
+                                 200017      │ 200017        │ 200017        │ 200017        │         │
+                                 23.22 MB    │ 23.22 MB      │ 23.22 MB      │ 23.22 MB      │         │
+ */

--- a/crates/mitex-spec/benches/constructions.rs
+++ b/crates/mitex-spec/benches/constructions.rs
@@ -33,6 +33,41 @@ fn prelude_100000() {
     prelude_n(100000);
 }
 
+fn bench_json_deserialize(bencher: Bencher, n: i32) {
+    use mitex_spec::query;
+    const JSON_TEX_SYMBOL: query::CommandSpecItem = query::CommandSpecItem::Cmd(query::CmdShape {
+        args: query::ArgShape::Right(query::ArgPattern::None),
+        alias: None,
+    });
+
+    let mut spec = query::CommandSpecRepr::default();
+    for i in 0..n {
+        spec.commands.insert(format!("alpha{}", i), JSON_TEX_SYMBOL);
+    }
+
+    let bytes = serde_json::to_vec(&spec).unwrap();
+    let bytes = bytes.as_slice();
+
+    bencher.bench(|| {
+        let _: query::CommandSpecRepr = serde_json::from_slice(bytes).unwrap();
+    });
+}
+
+#[divan::bench]
+fn deserialize_json_1(bencher: Bencher) {
+    bench_json_deserialize(bencher, 1);
+}
+
+#[divan::bench]
+fn deserialize_json_1000(bencher: Bencher) {
+    bench_json_deserialize(bencher, 1000);
+}
+
+#[divan::bench]
+fn deserialize_json_100000(bencher: Bencher) {
+    bench_json_deserialize(bencher, 100000);
+}
+
 #[cfg(feature = "rkyv")]
 #[cfg(feature = "rkyv-validation")]
 fn bench_deserialize(bencher: Bencher, spec: CommandSpec) {
@@ -91,64 +126,85 @@ fn deserialize_trusted_100000(bencher: Bencher) {
 
 /*
 last^1
-constructions                  fastest       │ slowest       │ median        │ mean          │ samples │ iters
-├─ deserialize_1               199.8 ns      │ 11.09 µs      │ 299.8 ns      │ 397.8 ns      │ 100     │ 100
+onstructions                  fastest       │ slowest       │ median        │ mean          │ samples │ iters
+├─ deserialize_1               170.2 ns      │ 268.6 ns      │ 185.8 ns      │ 201 ns        │ 100     │ 6400
 │                              alloc:        │               │               │               │         │
 │                                3           │ 3             │ 3             │ 3             │         │
 │                                410 B       │ 410 B         │ 410 B         │ 410 B         │         │
 │                              dealloc:      │               │               │               │         │
 │                                3           │ 3             │ 3             │ 3             │         │
 │                                410 B       │ 410 B         │ 410 B         │ 410 B         │         │
-├─ deserialize_1000            107.7 µs      │ 596.8 µs      │ 117 µs        │ 124.2 µs      │ 100     │ 100
+├─ deserialize_1000            110.1 µs      │ 190.4 µs      │ 117.6 µs      │ 120.3 µs      │ 100     │ 100
 │                              alloc:        │               │               │               │         │
 │                                1002        │ 1002          │ 1002          │ 1002          │         │
 │                                173.8 KB    │ 173.8 KB      │ 173.8 KB      │ 173.8 KB      │         │
 │                              dealloc:      │               │               │               │         │
 │                                1002        │ 1002          │ 1002          │ 1002          │         │
 │                                173.8 KB    │ 173.8 KB      │ 173.8 KB      │ 173.8 KB      │         │
-├─ deserialize_100000          17.45 ms      │ 29.96 ms      │ 20.27 ms      │ 20.76 ms      │ 100     │ 100
+├─ deserialize_100000          17.17 ms      │ 27.64 ms      │ 19.4 ms       │ 19.92 ms      │ 100     │ 100
 │                              alloc:        │               │               │               │         │
 │                                100002      │ 100002        │ 100002        │ 100002        │         │
 │                                11.6 MB     │ 11.6 MB       │ 11.6 MB       │ 11.6 MB       │         │
 │                              dealloc:      │               │               │               │         │
 │                                100002      │ 100002        │ 100002        │ 100002        │         │
 │                                11.6 MB     │ 11.6 MB       │ 11.6 MB       │ 11.6 MB       │         │
-├─ deserialize_trusted_1       143.6 ns      │ 295.2 ns      │ 149.8 ns      │ 169 ns        │ 100     │ 6400
+├─ deserialize_json_1          199.8 ns      │ 12.79 µs      │ 199.8 ns      │ 382.8 ns      │ 100     │ 100
+│                              alloc:        │               │               │               │         │
+│                                2           │ 2             │ 2             │ 2             │         │
+│                                346 B       │ 346 B         │ 346 B         │ 346 B         │         │
+│                              dealloc:      │               │               │               │         │
+│                                2           │ 2             │ 2             │ 2             │         │
+│                                346 B       │ 346 B         │ 346 B         │ 346 B         │         │
+├─ deserialize_json_1000       235.2 µs      │ 626.4 µs      │ 268.5 µs      │ 292.3 µs      │ 100     │ 100
+│                              alloc:        │               │               │               │         │
+│                                1010        │ 1010          │ 1010          │ 1010          │         │
+│                                339.5 KB    │ 339.5 KB      │ 339.5 KB      │ 339.5 KB      │         │
+│                              dealloc:      │               │               │               │         │
+│                                1010        │ 1010          │ 1010          │ 1010          │         │
+│                                339.5 KB    │ 339.5 KB      │ 339.5 KB      │ 339.5 KB      │         │
+├─ deserialize_json_100000     26.02 ms      │ 41.23 ms      │ 30.41 ms      │ 30.67 ms      │ 100     │ 100
+│                              alloc:        │               │               │               │         │
+│                                100016      │ 100016        │ 100016        │ 100016        │         │
+│                                22.22 MB    │ 22.22 MB      │ 22.22 MB      │ 22.22 MB      │         │
+│                              dealloc:      │               │               │               │         │
+│                                100016      │ 100016        │ 100016        │ 100016        │         │
+│                                22.22 MB    │ 22.22 MB      │ 22.22 MB      │ 22.22 MB      │         │
+├─ deserialize_trusted_1       145.9 ns      │ 167.8 ns      │ 154.5 ns      │ 153.3 ns      │ 100     │ 12800
 │                              alloc:        │               │               │               │         │
 │                                3           │ 3             │ 3             │ 3             │         │
 │                                410 B       │ 410 B         │ 410 B         │ 410 B         │         │
 │                              dealloc:      │               │               │               │         │
 │                                3           │ 3             │ 3             │ 3             │         │
 │                                410 B       │ 410 B         │ 410 B         │ 410 B         │         │
-├─ deserialize_trusted_1000    80.59 µs      │ 568.8 µs      │ 154.1 µs      │ 163.1 µs      │ 100     │ 100
+├─ deserialize_trusted_1000    64.59 µs      │ 265.3 µs      │ 79.59 µs      │ 86.64 µs      │ 100     │ 100
 │                              alloc:        │               │               │               │         │
 │                                1002        │ 1002          │ 1002          │ 1002          │         │
 │                                173.8 KB    │ 173.8 KB      │ 173.8 KB      │ 173.8 KB      │         │
 │                              dealloc:      │               │               │               │         │
 │                                1002        │ 1002          │ 1002          │ 1002          │         │
 │                                173.8 KB    │ 173.8 KB      │ 173.8 KB      │ 173.8 KB      │         │
-├─ deserialize_trusted_100000  10.86 ms      │ 20.24 ms      │ 14.07 ms      │ 14.24 ms      │ 100     │ 100
+├─ deserialize_trusted_100000  11.09 ms      │ 18.9 ms       │ 14.18 ms      │ 14.34 ms      │ 100     │ 100
 │                              alloc:        │               │               │               │         │
 │                                100002      │ 100002        │ 100002        │ 100002        │         │
 │                                11.6 MB     │ 11.6 MB       │ 11.6 MB       │ 11.6 MB       │         │
 │                              dealloc:      │               │               │               │         │
 │                                100002      │ 100002        │ 100002        │ 100002        │         │
 │                                11.6 MB     │ 11.6 MB       │ 11.6 MB       │ 11.6 MB       │         │
-├─ prelude_1                   193.6 ns      │ 226.4 ns      │ 198.3 ns      │ 203.5 ns      │ 100     │ 6400
+├─ prelude_1                   176.4 ns      │ 209.2 ns      │ 188.9 ns      │ 189.7 ns      │ 100     │ 6400
 │                              alloc:        │               │               │               │         │
 │                                4           │ 4             │ 4             │ 4             │         │
 │                                420 B       │ 420 B         │ 420 B         │ 420 B         │         │
 │                              dealloc:      │               │               │               │         │
 │                                4           │ 4             │ 4             │ 4             │         │
 │                                420 B       │ 420 B         │ 420 B         │ 420 B         │         │
-├─ prelude_1000                182.7 µs      │ 2.092 ms      │ 216.3 µs      │ 250.5 µs      │ 100     │ 100
+├─ prelude_1000                158.3 µs      │ 487.2 µs      │ 223.9 µs      │ 236.5 µs      │ 100     │ 100
 │                              alloc:        │               │               │               │         │
 │                                2011        │ 2011          │ 2011          │ 2011          │         │
 │                                349.5 KB    │ 349.5 KB      │ 349.5 KB      │ 349.5 KB      │         │
 │                              dealloc:      │               │               │               │         │
 │                                2011        │ 2011          │ 2011          │ 2011          │         │
 │                                349.5 KB    │ 349.5 KB      │ 349.5 KB      │ 349.5 KB      │         │
-╰─ prelude_100000              20.84 ms      │ 33.22 ms      │ 24.95 ms      │ 25.48 ms      │ 100     │ 100
+╰─ prelude_100000              19.85 ms      │ 33.71 ms      │ 24.55 ms      │ 24.93 ms      │ 100     │ 100
                                alloc:        │               │               │               │         │
                                  200017      │ 200017        │ 200017        │ 200017        │         │
                                  23.22 MB    │ 23.22 MB      │ 23.22 MB      │ 23.22 MB      │         │

--- a/crates/mitex-spec/src/lib.rs
+++ b/crates/mitex-spec/src/lib.rs
@@ -15,7 +15,9 @@ use std::{collections::HashMap, sync::Arc};
 use rkyv::{Archive, Deserialize as rDeser, Serialize as rSer};
 
 pub mod preludes;
+pub mod query;
 mod stream;
+pub use query::CommandSpecRepr as JsonCommandSpec;
 
 /// An item of command specification.
 /// It is either a command or an environment.

--- a/crates/mitex-spec/src/lib.rs
+++ b/crates/mitex-spec/src/lib.rs
@@ -11,6 +11,8 @@
 
 use std::{collections::HashMap, sync::Arc};
 
+pub mod preludes;
+
 /// An item of command specification.
 /// It is either a command or an environment.
 #[derive(Debug, Clone)]

--- a/crates/mitex-spec/src/preludes.rs
+++ b/crates/mitex-spec/src/preludes.rs
@@ -1,0 +1,101 @@
+pub mod command {
+    use crate::{ArgShape, CommandSpecItem};
+
+    pub fn define_command(num: u8) -> CommandSpecItem {
+        CommandSpecItem::Cmd(crate::CmdShape {
+            args: crate::ArgShape::Right(crate::ArgPattern::FixedLenTerm(num)),
+            alias: None,
+        })
+    }
+
+    pub fn define_glob_command(reg: &str, alias: &str) -> CommandSpecItem {
+        CommandSpecItem::Cmd(crate::CmdShape {
+            args: crate::ArgShape::Right(crate::ArgPattern::Glob(reg.into())),
+            alias: Some(alias.to_owned()),
+        })
+    }
+
+    pub fn define_symbol(alias: &str) -> CommandSpecItem {
+        CommandSpecItem::Cmd(crate::CmdShape {
+            args: crate::ArgShape::Right(crate::ArgPattern::None),
+            alias: Some(alias.to_owned()),
+        })
+    }
+
+    pub fn define_command_with_alias(num: u8, alias: &str) -> CommandSpecItem {
+        CommandSpecItem::Cmd(crate::CmdShape {
+            args: crate::ArgShape::Right(crate::ArgPattern::FixedLenTerm(num)),
+            alias: Some(alias.to_owned()),
+        })
+    }
+
+    pub fn define_greedy_command(alias: &str) -> CommandSpecItem {
+        CommandSpecItem::Cmd(crate::CmdShape {
+            args: crate::ArgShape::Right(crate::ArgPattern::Greedy),
+            alias: Some(alias.to_owned()),
+        })
+    }
+
+    pub fn define_matrix_env(num: Option<u8>, alias: &str) -> CommandSpecItem {
+        CommandSpecItem::Env(crate::EnvShape {
+            args: num
+                .map(crate::ArgPattern::FixedLenTerm)
+                .unwrap_or(crate::ArgPattern::None),
+            ctx_feature: crate::ContextFeature::IsMatrix,
+            alias: Some(alias.to_owned()),
+        })
+    }
+
+    pub fn define_normal_env(num: Option<u8>, alias: &str) -> CommandSpecItem {
+        CommandSpecItem::Env(crate::EnvShape {
+            args: num
+                .map(crate::ArgPattern::FixedLenTerm)
+                .unwrap_or(crate::ArgPattern::None),
+            ctx_feature: crate::ContextFeature::None,
+            alias: Some(alias.to_owned()),
+        })
+    }
+    pub const fn define_const_command(args: ArgShape) -> CommandSpecItem {
+        CommandSpecItem::Cmd(crate::CmdShape { args, alias: None })
+    }
+
+    pub const TEX_CMD0: CommandSpecItem =
+        define_const_command(crate::ArgShape::Right(crate::ArgPattern::FixedLenTerm(0)));
+    pub const TEX_CMD1: CommandSpecItem =
+        define_const_command(crate::ArgShape::Right(crate::ArgPattern::FixedLenTerm(1)));
+    pub const TEX_CMD2: CommandSpecItem =
+        define_const_command(crate::ArgShape::Right(crate::ArgPattern::FixedLenTerm(2)));
+    pub const TEX_SYMBOL: CommandSpecItem =
+        define_const_command(crate::ArgShape::Right(crate::ArgPattern::None));
+    pub const TEX_LEFT1_OPEARTOR: CommandSpecItem = define_const_command(crate::ArgShape::Left1);
+    pub const TEX_GREEDY_OPERATOR: CommandSpecItem =
+        define_const_command(crate::ArgShape::Right(crate::ArgPattern::Greedy));
+    pub const TEX_INFIX_OPERATOR: CommandSpecItem =
+        define_const_command(crate::ArgShape::InfixGreedy);
+    pub const TEX_MATRIX_ENV: CommandSpecItem = CommandSpecItem::Env(crate::EnvShape {
+        args: crate::ArgPattern::None,
+        ctx_feature: crate::ContextFeature::IsMatrix,
+        alias: None,
+    });
+    pub const TEX_NORMAL_ENV: CommandSpecItem = CommandSpecItem::Env(crate::EnvShape {
+        args: crate::ArgPattern::None,
+        ctx_feature: crate::ContextFeature::None,
+        alias: None,
+    });
+
+    #[derive(Default)]
+    pub struct SpecBuilder {
+        commands: std::collections::HashMap<String, CommandSpecItem>,
+    }
+
+    impl SpecBuilder {
+        pub fn add_command(&mut self, name: &str, item: CommandSpecItem) -> &mut Self {
+            self.commands.insert(name.to_owned(), item);
+            self
+        }
+
+        pub fn build(self) -> crate::CommandSpec {
+            crate::CommandSpec::new(self.commands)
+        }
+    }
+}

--- a/crates/mitex-spec/src/query.rs
+++ b/crates/mitex-spec/src/query.rs
@@ -1,0 +1,148 @@
+use std::{collections::HashMap, sync::Arc};
+
+use serde::{Deserialize, Serialize};
+
+/// An item of command specification.
+/// This contains more sugar than the canonical representation.
+///
+/// See [`mitex_spec::CommandSpecItem`] for more details.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub enum CommandSpecItem {
+    Cmd(CmdShape),
+    Env(EnvShape),
+    /// A command that takes no argument, and its handler is also a typst
+    /// symbol.
+    Symbol,
+    /// A command that takes zero argument, and its handler is a typst function.
+    Command0,
+    /// A command that takes one argument.
+    Command1,
+    /// A command that takes two arguments.
+    Command2,
+}
+
+impl From<CommandSpecItem> for crate::CommandSpecItem {
+    fn from(item: CommandSpecItem) -> Self {
+        use crate::preludes::command::*;
+        match item {
+            CommandSpecItem::Cmd(shape) => Self::Cmd(shape.into()),
+            CommandSpecItem::Env(shape) => Self::Env(shape.into()),
+            CommandSpecItem::Symbol => TEX_SYMBOL,
+            CommandSpecItem::Command0 => TEX_CMD0,
+            CommandSpecItem::Command1 => TEX_CMD1,
+            CommandSpecItem::Command2 => TEX_CMD2,
+        }
+    }
+}
+
+#[derive(Default, Debug, Clone, Serialize, Deserialize)]
+pub struct CommandSpecRepr {
+    pub commands: HashMap<String, CommandSpecItem>,
+}
+
+impl From<CommandSpecRepr> for crate::CommandSpec {
+    fn from(repr: CommandSpecRepr) -> Self {
+        Self(Arc::new(repr.into()))
+    }
+}
+
+impl From<CommandSpecRepr> for crate::CommandSpecRepr {
+    fn from(repr: CommandSpecRepr) -> Self {
+        Self {
+            commands: repr
+                .commands
+                .into_iter()
+                .map(|(k, v)| (k, v.into()))
+                .collect(),
+        }
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct CmdShape {
+    pub args: ArgShape,
+    pub alias: Option<String>,
+}
+
+impl From<CmdShape> for crate::CmdShape {
+    fn from(shape: CmdShape) -> Self {
+        Self {
+            args: shape.args.into(),
+            alias: shape.alias,
+        }
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct EnvShape {
+    pub args: ArgPattern,
+    pub ctx_feature: ContextFeature,
+    pub alias: Option<String>,
+}
+
+impl From<EnvShape> for crate::EnvShape {
+    fn from(shape: EnvShape) -> Self {
+        Self {
+            args: shape.args.into(),
+            ctx_feature: shape.ctx_feature.into(),
+            alias: shape.alias,
+        }
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub enum ArgPattern {
+    None,
+    FixedLenTerm(u8),
+    RangeLenTerm(u8, u8),
+    Greedy,
+    Glob(Box<str>),
+}
+
+impl From<ArgPattern> for crate::ArgPattern {
+    fn from(pattern: ArgPattern) -> Self {
+        match pattern {
+            ArgPattern::None => Self::None,
+            ArgPattern::FixedLenTerm(len) => Self::FixedLenTerm(len),
+            ArgPattern::RangeLenTerm(min, max) => Self::RangeLenTerm(min, max),
+            ArgPattern::Greedy => Self::Greedy,
+            ArgPattern::Glob(glob) => Self::Glob(glob.into()),
+        }
+    }
+}
+
+// struct ArgShape(ArgPattern, Direction);
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub enum ArgShape {
+    Right(ArgPattern),
+    Left1,
+    InfixGreedy,
+}
+
+impl From<ArgShape> for crate::ArgShape {
+    fn from(shape: ArgShape) -> Self {
+        match shape {
+            ArgShape::Right(pattern) => Self::Right(pattern.into()),
+            ArgShape::Left1 => Self::Left1,
+            ArgShape::InfixGreedy => Self::InfixGreedy,
+        }
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub enum ContextFeature {
+    None,
+    IsMatrix,
+    IsCases,
+}
+
+impl From<ContextFeature> for crate::ContextFeature {
+    fn from(feature: ContextFeature) -> Self {
+        match feature {
+            ContextFeature::None => Self::None,
+            ContextFeature::IsMatrix => Self::IsMatrix,
+            ContextFeature::IsCases => Self::IsCases,
+        }
+    }
+}

--- a/crates/mitex-spec/src/stream.rs
+++ b/crates/mitex-spec/src/stream.rs
@@ -1,0 +1,62 @@
+use super::{ArchivedCommandSpecRepr, CommandSpecRepr};
+use rkyv::de::deserializers::SharedDeserializeMap;
+use rkyv::{AlignedVec, Deserialize};
+
+enum RkyvStreamData<'a> {
+    Aligned(&'a [u8]),
+    Unaligned(AlignedVec),
+}
+
+impl<'a> AsRef<[u8]> for RkyvStreamData<'a> {
+    #[inline]
+    fn as_ref(&self) -> &[u8] {
+        match self {
+            Self::Aligned(v) => v,
+            Self::Unaligned(v) => v.as_slice(),
+        }
+    }
+}
+
+pub struct BytesModuleStream<'a> {
+    data: RkyvStreamData<'a>,
+}
+
+impl<'a> BytesModuleStream<'a> {
+    pub fn from_slice(v: &'a [u8]) -> Self {
+        let v = if (v.as_ptr() as usize) % AlignedVec::ALIGNMENT != 0 {
+            let mut aligned = AlignedVec::with_capacity(v.len());
+            aligned.extend_from_slice(v);
+            RkyvStreamData::Unaligned(aligned)
+        } else {
+            RkyvStreamData::Aligned(v)
+        };
+
+        Self { data: v }
+    }
+
+    #[cfg(feature = "rkyv-validation")]
+    pub fn checkout(&self) -> &ArchivedCommandSpecRepr {
+        rkyv::check_archived_root::<CommandSpecRepr>(self.data.as_ref()).unwrap()
+    }
+
+    /// # Safety
+    /// The data source must be trusted and valid.
+    pub unsafe fn checkout_unchecked(&self) -> &ArchivedCommandSpecRepr {
+        rkyv::archived_root::<CommandSpecRepr>(self.data.as_ref())
+    }
+
+    #[cfg(feature = "rkyv-validation")]
+    pub fn checkout_owned(&self) -> CommandSpecRepr {
+        let v = self.checkout();
+        let mut dmap = SharedDeserializeMap::default();
+        v.deserialize(&mut dmap).unwrap()
+    }
+
+    /// # Safety
+    /// The data source must be trusted and valid.
+    pub unsafe fn checkout_owned_unchecked(&self) -> CommandSpecRepr {
+        let v = self.checkout_unchecked();
+        let mut dmap = SharedDeserializeMap::default();
+        v.deserialize(&mut dmap).unwrap()
+    }
+}

--- a/crates/mitex-typst/Cargo.toml
+++ b/crates/mitex-typst/Cargo.toml
@@ -14,3 +14,10 @@ crate-type = ["cdylib"]
 [dependencies]
 wasm-minimal-protocol = { git = "https://github.com/astrale-sharp/wasm-minimal-protocol" }
 mitex = { path = "../mitex" }
+mitex-spec = { path = "../mitex-spec" }
+serde = "1.0.188"
+serde_json = "1.0.106"
+
+
+[features]
+rkyv = ["mitex-spec/rkyv", "mitex-spec/rkyv-validation"]

--- a/crates/mitex/src/lib.rs
+++ b/crates/mitex/src/lib.rs
@@ -400,9 +400,8 @@ impl fmt::Display for TypstMathRepr {
     }
 }
 
-pub fn convert_math(input: &str) -> Result<String, String> {
-    // let input = std::str::from_utf8(input).map_err(|e| e.to_string())?;
-    let node = parse(input, DEFAULT_SPEC.clone());
+pub fn convert_math(input: &str, spec: Option<CommandSpec>) -> Result<String, String> {
+    let node = parse(input, spec.unwrap_or_else(|| DEFAULT_SPEC.clone()));
     // println!("{:#?}", node);
     // println!("{:#?}", node.text());
     let mut output = String::new();
@@ -547,9 +546,18 @@ fn default_spec() -> CommandSpec {
     builder.add_command("overline", TEX_CMD1);
     builder.add_command("underline", TEX_CMD1);
     builder.add_command("overbrace", define_command_with_alias(1, "mitexoverbrace"));
-    builder.add_command("underbrace", define_command_with_alias(1, "mitexunderbrace"));
-    builder.add_command("overbracket", define_command_with_alias(1, "mitexoverbracket"));
-    builder.add_command("underbracket", define_command_with_alias(1, "mitexunderbracket"));
+    builder.add_command(
+        "underbrace",
+        define_command_with_alias(1, "mitexunderbrace"),
+    );
+    builder.add_command(
+        "overbracket",
+        define_command_with_alias(1, "mitexoverbracket"),
+    );
+    builder.add_command(
+        "underbracket",
+        define_command_with_alias(1, "mitexunderbracket"),
+    );
     // Greeks
     builder.add_command("alpha", TEX_SYMBOL);
     builder.add_command("beta", TEX_SYMBOL);
@@ -1036,8 +1044,11 @@ static DEFAULT_SPEC: once_cell::sync::Lazy<CommandSpec> = once_cell::sync::Lazy:
 
 #[cfg(test)]
 mod tests {
-    use super::*;
     use insta::assert_debug_snapshot;
+
+    fn convert_math(input: &str) -> Result<String, String> {
+        crate::convert_math(input, None)
+    }
 
     #[test]
     fn test_convert_word() {

--- a/typst-package/mitex.typ
+++ b/typst-package/mitex.typ
@@ -1,7 +1,7 @@
 #import "@preview/xarrow:0.2.0": xarrow
 #let mitex-wasm = plugin("./mitex.wasm")
 
-#let mitex-convert(it) = {
+#let mitex-convert(it, spec: bytes(())) = {
   str(mitex-wasm.convert_math(bytes({
     if type(it) == str {
       it
@@ -10,7 +10,7 @@
     } else {
       panic("Unsupported type: " + str(type(it)))
     }
-  })))
+  }), spec))
 }
 
 #let mitex-color-map = (


### PR DESCRIPTION
+ move command preludes to `mitex_spec` for benchmark.
+ add JSON and rkyv serialization to `mitex_spec::CommandSpec`, see crates/mitex-spec/benches/constructions.rs for performance comparison.
+ add compile_spec api to WASM library
  + but we don't provide it by package, since it is not mature enough.
+ add `spec` optional argument to `mitex-convert` API. I have benchmarked it by `typst-package/examples/bench.typ`, so far so good.