### PR TITLE
dev: disable compile_spec api

### DIFF
--- a/crates/mitex-typst/src/lib.rs
+++ b/crates/mitex-typst/src/lib.rs
@@ -3,6 +3,7 @@ use wasm_minimal_protocol::*;
 
 initiate_protocol!();
 
+#[cfg(feature = "spec-api")]
 #[wasm_func]
 pub fn compile_spec(input: &[u8]) -> Result<Vec<u8>, String> {
     let res: mitex_spec::JsonCommandSpec =


### PR DESCRIPTION
We currently don't need to have it. By removing it, the size of wasm binary comes to 185KB