### PR TITLE
dev(m_engine): switch to lexer with macro engine

### DIFF
--- a/crates/mitex-parser/benches/simple.rs
+++ b/crates/mitex-parser/benches/simple.rs
@@ -1,5 +1,5 @@
 use divan::{AllocProfiler, Bencher};
-use mitex_parser::{parse, parse_with_macro, CommandSpec};
+use mitex_parser::{parse, parse_without_macro, CommandSpec};
 
 #[global_allocator]
 static ALLOC: AllocProfiler = AllocProfiler::system();
@@ -40,8 +40,8 @@ fn bench(bencher: Bencher, input: &str, spec: CommandSpec) {
     bencher.bench(|| parse(input, spec.clone()));
 }
 
-fn bench_macro(bencher: Bencher, input: &str, spec: CommandSpec) {
-    bencher.bench(|| parse_with_macro(input, spec.clone()));
+fn bench_no_macro(bencher: Bencher, input: &str, spec: CommandSpec) {
+    bencher.bench(|| parse_without_macro(input, spec.clone()));
 }
 
 #[divan::bench]
@@ -55,8 +55,8 @@ fn alpha_x_40000(bencher: Bencher) {
 }
 
 #[divan::bench]
-fn alpha_x_40000_macro(bencher: Bencher) {
-    bench_macro(bencher, &ALPHA_X_40000, DEFAULT_SPEC.clone());
+fn alpha_x_40000_no_macro(bencher: Bencher) {
+    bench_no_macro(bencher, &ALPHA_X_40000, DEFAULT_SPEC.clone());
 }
 
 #[divan::bench]
@@ -94,8 +94,8 @@ fn plain_text(bencher: Bencher) {
 }
 
 #[divan::bench]
-fn plain_text_macro(bencher: Bencher) {
-    bench_macro(bencher, &PLAIN_TEXT, DEFAULT_SPEC.clone());
+fn plain_text_no_macro(bencher: Bencher) {
+    bench_no_macro(bencher, &PLAIN_TEXT, DEFAULT_SPEC.clone());
 }
 
 static STARRED_COMMAND: once_cell::sync::Lazy<String> =
@@ -107,8 +107,8 @@ fn starred_command(bencher: Bencher) {
 }
 
 #[divan::bench]
-fn starred_command_macro(bencher: Bencher) {
-    bench_macro(bencher, &STARRED_COMMAND, DEFAULT_SPEC.clone());
+fn starred_command_no_macro(bencher: Bencher) {
+    bench_no_macro(bencher, &STARRED_COMMAND, DEFAULT_SPEC.clone());
 }
 
 /*

--- a/crates/mitex-parser/src/lib.rs
+++ b/crates/mitex-parser/src/lib.rs
@@ -14,10 +14,10 @@ use parser::Parser;
 ///
 /// The error nodes are attached to the tree
 pub fn parse(input: &str, spec: CommandSpec) -> SyntaxNode {
-    SyntaxNode::new_root(Parser::new(input, spec).parse())
+    SyntaxNode::new_root(Parser::new_macro(input, spec).parse())
 }
 
 /// It is only for internal testing
-pub fn parse_with_macro(input: &str, spec: CommandSpec) -> SyntaxNode {
-    SyntaxNode::new_root(Parser::new_macro(input, spec).parse())
+pub fn parse_without_macro(input: &str, spec: CommandSpec) -> SyntaxNode {
+    SyntaxNode::new_root(Parser::new(input, spec).parse())
 }

--- a/crates/mitex-parser/src/parser.rs
+++ b/crates/mitex-parser/src/parser.rs
@@ -240,12 +240,7 @@ impl<'a, S: BumpTokenStream<'a>> Parser<'a, S> {
     /// Lexer Interface
     /// Consume tokens until the next non-trivia token
     fn trivia(&mut self) {
-        fn is_trivia(kind: Token) -> bool {
-            use Token::*;
-            matches!(kind, LineBreak | Whitespace | LineComment)
-        }
-
-        while self.peek().map_or(false, is_trivia) {
+        while self.peek().as_ref().map_or(false, Token::is_trivia) {
             self.eat();
         }
     }
@@ -359,7 +354,8 @@ impl<'a, S: BumpTokenStream<'a>> Parser<'a, S> {
             | Token::NewLine
             | Token::LineBreak
             | Token::Whitespace
-            | Token::LineComment => {
+            | Token::LineComment
+            | Token::Error => {
                 self.eat();
                 return false;
             }

--- a/crates/mitex-parser/src/syntax.rs
+++ b/crates/mitex-parser/src/syntax.rs
@@ -77,6 +77,7 @@ impl From<Token> for SyntaxKind {
             Token::Dollar => SyntaxKind::TokenDollar,
             Token::Ampersand => SyntaxKind::TokenAmpersand,
             Token::NewLine => SyntaxKind::ItemNewLine,
+            Token::Error => SyntaxKind::TokenError,
             Token::CommandName(_) => SyntaxKind::ClauseCommandName,
         }
     }

--- a/crates/mitex/benches/convert_large_projects.rs
+++ b/crates/mitex/benches/convert_large_projects.rs
@@ -30,9 +30,9 @@ fn bench<const WITH_MACRO: bool>(bencher: Bencher, path: &str) {
     let data = serde_json::from_str::<Vec<Fixture>>(&v).unwrap();
 
     let convert = if WITH_MACRO {
-        mitex::convert_math_macro
-    } else {
         mitex::convert_math
+    } else {
+        mitex::convert_math_no_macro
     };
 
     // warm up

--- a/crates/mitex/benches/convert_large_projects.rs
+++ b/crates/mitex/benches/convert_large_projects.rs
@@ -57,7 +57,40 @@ fn oiwiki_231222_macro(bencher: Bencher) {
 
 /*
 
-last^1 (typst v0.10.0)
+last^1 (macro support, typst v0.10.0)
+Benchmark 1: typst compile --root . crates\mitex\benches\empty.typ
+  Time (mean ± σ):     399.6 ms ±  36.6 ms    [User: 75.0 ms, System: 26.6 ms]
+  Range (min … max):   371.0 ms … 495.5 ms    10 runs
+Benchmark 1: typst compile --root . crates\mitex\benches\oiwiki.typ
+  Time (mean ± σ):      2.179 s ±  0.029 s    [User: 0.681 s, System: 0.049 s]
+  Range (min … max):    2.142 s …  2.229 s    10 runs
+Benchmark 1: typst compile --root . crates\mitex\benches\oiwiki-with-render.typ
+  Time (mean ± σ):      3.830 s ±  0.021 s    [User: 1.223 s, System: 0.168 s]
+  Range (min … max):    3.787 s …  3.867 s    10 runs
+
+convert_large_projects  fastest       │ slowest       │ median        │ mean          │ samples │ iters
+├─ oiwiki_231222        79.07 ms      │ 87.49 ms      │ 80.94 ms      │ 81.26 ms      │ 100     │ 100
+│                       alloc:        │               │               │               │         │
+│                         1361478     │ 1361478       │ 1361478       │ 1361478       │         │
+│                         84.71 MB    │ 84.71 MB      │ 84.71 MB      │ 84.71 MB      │         │
+│                       dealloc:      │               │               │               │         │
+│                         1361478     │ 1361478       │ 1361478       │ 1361478       │         │
+│                         93.27 MB    │ 93.27 MB      │ 93.27 MB      │ 93.27 MB      │         │
+│                       grow:         │               │               │               │         │
+│                         64098       │ 64098         │ 64098         │ 64098         │         │
+│                         8.556 MB    │ 8.556 MB      │ 8.556 MB      │ 8.556 MB      │         │
+╰─ oiwiki_231222_macro  79.46 ms      │ 140.6 ms      │ 84.31 ms      │ 85.6 ms       │ 100     │ 100
+                        alloc:        │               │               │               │         │
+                          1361478     │ 1361478       │ 1361478       │ 1361478       │         │
+                          84.71 MB    │ 84.71 MB      │ 84.71 MB      │ 84.71 MB      │         │
+                        dealloc:      │               │               │               │         │
+                          1361478     │ 1361478       │ 1361478       │ 1361478       │         │
+                          93.27 MB    │ 93.27 MB      │ 93.27 MB      │ 93.27 MB      │         │
+                        grow:         │               │               │               │         │
+                          64098       │ 64098         │ 64098         │ 64098         │         │
+                          8.556 MB    │ 8.556 MB      │ 8.556 MB      │ 8.556 MB      │         │
+
+baseline (typst v0.10.0)
 Benchmark 1: typst compile --root . crates\mitex\benches\empty.typ
   Time (mean ± σ):     379.0 ms ±   8.8 ms    [User: 101.2 ms, System: 32.8 ms]
   Range (min … max):   369.9 ms … 396.6 ms    10 runs


### PR DESCRIPTION
MiTeX starts to support macro evaluation. Currently it simply removes all macro definitions, which is still an improvement. For example,

```
\newcommand{\x}{y}
f(x)
```

Before, it is converted into

```
{\x}{y}
f(x)
```

After, it is converted into:

```
f(x)
```

Nevertheless, if users doesn't use macros at all, the performance keeps same:

```
baseline (mitex v0.1.0, typst v0.10.0)
Benchmark 1: typst compile --root . crates\mitex\benches\empty.typ
  Time (mean ± σ):     379.0 ms ±   8.8 ms    [User: 101.2 ms, System: 32.8 ms]
  Range (min … max):   369.9 ms … 396.6 ms    10 runs
Benchmark 1: typst compile --root . crates\mitex\benches\oiwiki.typ
  Time (mean ± σ):      2.214 s ±  0.073 s    [User: 0.469 s, System: 0.031 s]
  Range (min … max):    2.096 s …  2.316 s    10 runs
Benchmark 1: typst compile --root . crates\mitex\benches\oiwiki-with-render.typ
  Time (mean ± σ):      3.772 s ±  0.088 s    [User: 1.165 s, System: 0.102 s]
  Range (min … max):    3.591 s …  3.897 s    10 runs

last^1 (mitex with macro support, typst v0.10.0)
Benchmark 1: typst compile --root . crates\mitex\benches\empty.typ
  Time (mean ± σ):     399.6 ms ±  36.6 ms    [User: 75.0 ms, System: 26.6 ms]
  Range (min … max):   371.0 ms … 495.5 ms    10 runs
Benchmark 1: typst compile --root . crates\mitex\benches\oiwiki.typ
  Time (mean ± σ):      2.179 s ±  0.029 s    [User: 0.681 s, System: 0.049 s]
  Range (min … max):    2.142 s …  2.229 s    10 runs
Benchmark 1: typst compile --root . crates\mitex\benches\oiwiki-with-render.typ
  Time (mean ± σ):      3.830 s ±  0.021 s    [User: 1.223 s, System: 0.168 s]
  Range (min … max):    3.787 s …  3.867 s    10 runs

convert_large_projects  fastest       │ slowest       │ median        │ mean          │ samples │ iters
├─ oiwiki_231222        79.07 ms      │ 87.49 ms      │ 80.94 ms      │ 81.26 ms      │ 100     │ 100
│                       alloc:        │               │               │               │         │
│                         1361478     │ 1361478       │ 1361478       │ 1361478       │         │
│                         84.71 MB    │ 84.71 MB      │ 84.71 MB      │ 84.71 MB      │         │
│                       dealloc:      │               │               │               │         │
│                         1361478     │ 1361478       │ 1361478       │ 1361478       │         │
│                         93.27 MB    │ 93.27 MB      │ 93.27 MB      │ 93.27 MB      │         │
│                       grow:         │               │               │               │         │
│                         64098       │ 64098         │ 64098         │ 64098         │         │
│                         8.556 MB    │ 8.556 MB      │ 8.556 MB      │ 8.556 MB      │         │
╰─ oiwiki_231222_macro  79.46 ms      │ 140.6 ms      │ 84.31 ms      │ 85.6 ms       │ 100     │ 100
                        alloc:        │               │               │               │         │
                          1361478     │ 1361478       │ 1361478       │ 1361478       │         │
                          84.71 MB    │ 84.71 MB      │ 84.71 MB      │ 84.71 MB      │         │
                        dealloc:      │               │               │               │         │
                          1361478     │ 1361478       │ 1361478       │ 1361478       │         │
                          93.27 MB    │ 93.27 MB      │ 93.27 MB      │ 93.27 MB      │         │
                        grow:         │               │               │               │         │
                          64098       │ 64098         │ 64098         │ 64098         │         │
                          8.556 MB    │ 8.556 MB      │ 8.556 MB      │ 8.556 MB      │         │
```