### PR TITLE
feat(m_engine): fully support to recursive macro command expansion

### DIFF
--- a/crates/mitex-lexer/tests/expand_macro.rs
+++ b/crates/mitex-lexer/tests/expand_macro.rs
@@ -40,6 +40,13 @@ fn no_macros() {
     Whitespace(" ")
     Word("world")
     "###);
+    assert_snapshot!(assert_plain_tokens("{a#1a}"), @r###"
+    Left(Curly)("{")
+    Word("a")
+    Hash("#")
+    Word("1a")
+    Right(Curly)("}")
+    "###);
 }
 
 // collect all tokens until eat() returns None
@@ -142,5 +149,28 @@ fn declare_macro() {
             ],
         },
     )
+    "###);
+}
+
+#[test]
+fn subst_macro() {
+    assert_snapshot!(tokens(r#"\newcommand{\f}[2]{#1f(#2)}\f\hat xy"#), @r###"
+    CommandName(Generic)("\\hat")
+    Word("f")
+    Left(Paren)("(")
+    Word("x")
+    Right(Paren)(")")
+    Word("y")
+    "###);
+}
+
+#[test]
+fn newcommand_recursive() {
+    assert_snapshot!(tokens(r#"\newcommand{\DeclareMathDelimit}[2]{\newcommand{#1}[1]{\left#2\mitexrecurse{#1}\right#2}}\DeclareMathDelimit{\abs}{\vert}\abs{abc}"#), @r###"
+    CommandName(Left)("\\left")
+    CommandName(Generic)("\\vert")
+    Word("abc")
+    CommandName(Right)("\\right")
+    CommandName(Generic)("\\vert")
     "###);
 }

--- a/crates/mitex-parser/src/parser.rs
+++ b/crates/mitex-parser/src/parser.rs
@@ -355,6 +355,7 @@ impl<'a, S: BumpTokenStream<'a>> Parser<'a, S> {
             | Token::LineBreak
             | Token::Whitespace
             | Token::LineComment
+            | Token::Hash
             | Token::Error => {
                 self.eat();
                 return false;
@@ -368,7 +369,7 @@ impl<'a, S: BumpTokenStream<'a>> Parser<'a, S> {
                 return false;
             }
             Token::Left(BraceKind::Curly) => self.item_group(ItemCurly),
-            Token::Right(BraceKind::Curly) => {
+            Token::Right(BraceKind::Curly) | Token::MacroArg(_) => {
                 self.builder.start_node(TokenError.into());
                 self.eat();
                 self.builder.finish_node();

--- a/crates/mitex-parser/src/syntax.rs
+++ b/crates/mitex-parser/src/syntax.rs
@@ -22,6 +22,7 @@ pub enum SyntaxKind {
     TokenWord,
     TokenDollar,
     TokenAmpersand,
+    TokenHash,
     TokenUnderscore,
     TokenCaret,
     TokenApostrophe,
@@ -76,8 +77,10 @@ impl From<Token> for SyntaxKind {
             Token::Word => SyntaxKind::TokenWord,
             Token::Dollar => SyntaxKind::TokenDollar,
             Token::Ampersand => SyntaxKind::TokenAmpersand,
+            Token::Hash => SyntaxKind::TokenHash,
             Token::NewLine => SyntaxKind::ItemNewLine,
             Token::Error => SyntaxKind::TokenError,
+            Token::MacroArg(_) => SyntaxKind::TokenWord,
             Token::CommandName(_) => SyntaxKind::ClauseCommandName,
         }
     }

--- a/crates/mitex-parser/tests/common/mod.rs
+++ b/crates/mitex-parser/tests/common/mod.rs
@@ -77,6 +77,7 @@ pub mod ast_snapshot {
                 SyntaxKind::TokenWord => "word'",
                 SyntaxKind::TokenDollar => "dollar'",
                 SyntaxKind::TokenAmpersand => "ampersand'",
+                SyntaxKind::TokenHash => "hash'",
                 SyntaxKind::TokenUnderscore => "underscore'",
                 SyntaxKind::TokenCaret => "caret'",
                 SyntaxKind::TokenApostrophe => "apostrophe'",

--- a/crates/mitex/src/lib.rs
+++ b/crates/mitex/src/lib.rs
@@ -223,6 +223,9 @@ impl MathConverter {
             TokenUnderscore => {
                 f.write_str("\\_")?;
             }
+            TokenHash => {
+                f.write_str("\\#")?;
+            }
             TokenDitto => {
                 f.write_str("\\\"")?;
             }

--- a/packages/mitex/examples/example.typ
+++ b/packages/mitex/examples/example.typ
@@ -9,7 +9,8 @@ Write inline equations like #mi("x") or #mi[y].
 Also block equations (this case is from #text(blue.lighten(20%), link("https://katex.org/")[katex.org])):
 
 #mitex(`
-  f(x) = \int_{-\infty}^\infty
-    \hat f(\xi)\,e^{2 \pi i \xi x}
+  \newcommand{\f}[2]{#1f(#2)}
+  \f\relax{x} = \int_{-\infty}^\infty
+    \f\hat\xi\,e^{2 \pi i \xi x}
     \,d\xi
 `)


### PR DESCRIPTION
These commands are supported
- \newcommand
- \newcommand*
- \renewcommand
- \renewcommand*
- \DeclareRobustCommand
- \DeclareRobustCommand*
- \providecommand
- \providecommand*

Also MiTeX provides an extra `\mitexrecurse` for defining commands recursively. For example:
```tex
\newcommand{\DeclarePairedDelimiter}[2]{
  \newcommand{#1}[1]{\left#2\mitexrecurse{#1}\right#2}
}
\DeclarePairedDelimiter{\abs}{\vert}
\abs{abc}
```
Which is equivalent to `|abc|`

`\mitexrecurse` is not for users, but useful when we define commands in spec.typ files.

